### PR TITLE
feat: Add chat feedback popup feature

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -5,6 +5,12 @@
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-57GKW4FT" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <NuxtPage />
     <UNotifications />
+
+    <!-- Feedback Components -->
+    <FeedbackButton @openFeedback="openFeedbackModal" />
+    <FeedbackModal :show="showFeedbackModal" @close="closeFeedbackModal" />
+    <!-- End Feedback Components -->
+
     <!--
     <div v-if="!hasConsent" class="fixed bottom-0 left-0 w-full bg-gray-200 dark:bg-gray-800 p-4 z-50 shadow-md">
       <div class="container mx-auto flex justify-between items-center">
@@ -28,6 +34,9 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
+// Import feedback components
+import FeedbackButton from '~/components/common/FeedbackButton.vue';
+import FeedbackModal from '~/components/common/FeedbackModal.vue';
 
 const agreedToCookiesScriptConsent = useScriptTriggerConsent();
 const hasConsent = ref(false);
@@ -85,6 +94,17 @@ onMounted(() => {
     // If no consent is stored, the consent form will be shown
   }
 });
+
+// Reactive state for feedback modal visibility
+const showFeedbackModal = ref(false);
+
+function openFeedbackModal() {
+  showFeedbackModal.value = true;
+}
+
+function closeFeedbackModal() {
+  showFeedbackModal.value = false;
+}
 </script>
 
 <style scoped>

--- a/app/components/common/FeedbackButton.vue
+++ b/app/components/common/FeedbackButton.vue
@@ -1,0 +1,20 @@
+<template>
+  <button
+    @click="handleClick"
+    class="fixed bottom-4 right-4 bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full shadow-lg z-50"
+  >
+    Feedback
+  </button>
+</template>
+
+<script setup lang="ts">
+const emit = defineEmits(['openFeedback']);
+
+function handleClick() {
+  emit('openFeedback');
+}
+</script>
+
+<style scoped>
+/* Add any additional styles if needed */
+</style>

--- a/app/components/common/FeedbackForm.vue
+++ b/app/components/common/FeedbackForm.vue
@@ -1,0 +1,96 @@
+<template>
+  <div>
+    <h2 class="text-xl font-bold mb-4 text-center">We’d love your feedback!</h2>
+    <form
+        action="https://formspree.io/f/xgvkdgwj"
+        method="POST"
+        class="flex flex-col gap-4"
+        @submit="handleSubmit"
+    >
+      <input
+          type="text"
+          name="name"
+          v-model="formData.name"
+          placeholder="Your Name"
+          required
+          class="p-3 rounded border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-700 dark:text-white"
+      />
+      <input
+          type="email"
+          name="email"
+          v-model="formData.email"
+          placeholder="Your Email"
+          required
+          class="p-3 rounded border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-700 dark:text-white"
+      />
+      <textarea
+          name="message"
+          v-model="formData.message"
+          placeholder="Your Feedback"
+          rows="5"
+          required
+          class="p-3 rounded border border-gray-300 dark:border-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-400 dark:bg-gray-700 dark:text-white"
+      ></textarea>
+
+      <div class="flex justify-end">
+        <button
+            type="submit"
+            :disabled="isSubmitting"
+            class="w-full sm:w-[220px] py-2 rounded-lg border-2 border-black dark:border-white font-bold cursor-pointer bg-white text-black dark:bg-gray-800 dark:text-white hover:bg-gray-200 dark:hover:bg-gray-700 text-base sm:text-lg md:text-xl transition-colors duration-300"
+        >
+          {{ isSubmitting ? 'Submitting...' : 'Submit Feedback' }}
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const formData = ref({
+  name: '',
+  email: '',
+  message: '',
+});
+
+const isSubmitting = ref(false);
+const emit = defineEmits(['close']);
+
+async function handleSubmit(event: Event) {
+  event.preventDefault();
+  isSubmitting.value = true;
+
+  const form = event.target as HTMLFormElement;
+  const data = new FormData(form);
+
+  try {
+    const response = await fetch(form.action, {
+      method: form.method,
+      body: data,
+      headers: {
+        'Accept': 'application/json'
+      }
+    });
+
+    if (response.ok) {
+      // Optionally, display a success message to the user
+      alert('Feedback submitted successfully!');
+      formData.value = { name: '', email: '', message: '' }; // Reset form
+      emit('close'); // Close the modal/form
+    } else {
+      // Handle errors (e.g., show an error message)
+      alert('There was an error submitting your feedback. Please try again.');
+    }
+  } catch (error) {
+    console.error('Form submission error:', error);
+    alert('There was an error submitting your feedback. Please try again.');
+  } finally {
+    isSubmitting.value = false;
+  }
+}
+</script>
+
+<style scoped>
+/* Add any additional styles if needed, ensuring they are scoped */
+</style>

--- a/app/components/common/FeedbackModal.vue
+++ b/app/components/common/FeedbackModal.vue
@@ -1,0 +1,27 @@
+<template>
+  <Modal :show="show" @close="handleClose">
+    <template #default>
+      <FeedbackForm @close="handleFormClose" />
+    </template>
+  </Modal>
+</template>
+
+<script setup lang="ts">
+import Modal from './Modal.vue'; // Assuming Modal.vue is in the same directory
+import FeedbackForm from './FeedbackForm.vue'; // Assuming FeedbackForm.vue is in the same directory
+
+defineProps<{
+  show: boolean;
+}>();
+
+const emit = defineEmits(['close']);
+
+function handleClose() {
+  emit('close');
+}
+
+function handleFormClose() {
+  // This is called when the form itself emits 'close' (e.g., after successful submission)
+  emit('close');
+}
+</script>

--- a/app/components/common/Modal.vue
+++ b/app/components/common/Modal.vue
@@ -11,7 +11,7 @@
         <slot name="title" />
       </header>
 
-      <div class="mb-6">
+      <div class="mb-6 max-h-[80vh] overflow-y-auto">
         <slot />
       </div>
 

--- a/app/components/common/tests/FeedbackButton.spec.ts
+++ b/app/components/common/tests/FeedbackButton.spec.ts
@@ -1,0 +1,22 @@
+// app/components/common/tests/FeedbackButton.spec.ts
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import FeedbackButton from '../FeedbackButton.vue'; // Adjust path as needed
+
+describe('FeedbackButton.vue', () => {
+  it('renders correctly', () => {
+    const wrapper = mount(FeedbackButton);
+    expect(wrapper.find('button').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Feedback');
+  });
+
+  it('emits openFeedback event when clicked', async () => {
+    const wrapper = mount(FeedbackButton);
+    const button = wrapper.find('button');
+
+    await button.trigger('click');
+
+    expect(wrapper.emitted()).toHaveProperty('openFeedback');
+    expect(wrapper.emitted().openFeedback).toHaveLength(1);
+  });
+});

--- a/app/components/common/tests/FeedbackForm.spec.ts
+++ b/app/components/common/tests/FeedbackForm.spec.ts
@@ -1,0 +1,93 @@
+// app/components/common/tests/FeedbackForm.spec.ts
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import FeedbackForm from '../FeedbackForm.vue'; // Adjust path as needed
+
+// Mock global fetch
+global.fetch = vi.fn();
+
+describe('FeedbackForm.vue', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.mocked(global.fetch).mockClear();
+    // Mock a successful response
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+    // Mock alert, as it's used in the component
+    global.alert = vi.fn();
+  });
+
+  it('renders all form fields and the submit button', () => {
+    const wrapper = mount(FeedbackForm);
+    expect(wrapper.find('input[name="name"]').exists()).toBe(true);
+    expect(wrapper.find('input[name="email"]').exists()).toBe(true);
+    expect(wrapper.find('textarea[name="message"]').exists()).toBe(true);
+    expect(wrapper.find('button[type="submit"]').exists()).toBe(true);
+  });
+
+  it('allows input into form fields', async () => {
+    const wrapper = mount(FeedbackForm);
+    await wrapper.find('input[name="name"]').setValue('Test Name');
+    await wrapper.find('input[name="email"]').setValue('test@example.com');
+    await wrapper.find('textarea[name="message"]').setValue('Test message');
+
+    expect((wrapper.find('input[name="name"]').element as HTMLInputElement).value).toBe('Test Name');
+    expect((wrapper.find('input[name="email"]').element as HTMLInputElement).value).toBe('test@example.com');
+    expect((wrapper.find('textarea[name="message"]').element as HTMLTextAreaElement).value).toBe('Test message');
+  });
+
+  it('submits the form, emits "close", and resets fields on successful submission', async () => {
+    const wrapper = mount(FeedbackForm);
+
+    await wrapper.find('input[name="name"]').setValue('Test Name');
+    await wrapper.find('input[name="email"]').setValue('test@example.com');
+    await wrapper.find('textarea[name="message"]').setValue('Test Feedback');
+
+    await wrapper.find('form').trigger('submit.prevent');
+
+    // Check if fetch was called
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    // Check for Formspree URL (optional, but good to ensure it's the right endpoint)
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://formspree.io/f/xgvkdgwj',
+      expect.any(Object) // Or more specific expectation for options
+    );
+
+    // Check for emitted event (needs a tick for promises to resolve)
+    await wrapper.vm.$nextTick(); // Allow time for async operations in handleSubmit
+    await wrapper.vm.$nextTick(); // Additional tick might be needed
+
+    expect(wrapper.emitted()).toHaveProperty('close');
+    expect(wrapper.emitted().close).toHaveLength(1);
+
+    // Check if form fields are reset
+    expect((wrapper.find('input[name="name"]').element as HTMLInputElement).value).toBe('');
+    expect((wrapper.find('input[name="email"]').element as HTMLInputElement).value).toBe('');
+    expect((wrapper.find('textarea[name="message"]').element as HTMLTextAreaElement).value).toBe('');
+  });
+
+  it('handles submission failure', async () => {
+    // Mock a failed response
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: false,
+    } as Response);
+    const alertSpy = vi.spyOn(global, 'alert');
+
+    const wrapper = mount(FeedbackForm);
+    await wrapper.find('input[name="name"]').setValue('Test Name');
+    await wrapper.find('input[name="email"]').setValue('test@example.com');
+    await wrapper.find('textarea[name="message"]').setValue('Test Feedback');
+    await wrapper.find('form').trigger('submit.prevent');
+
+    await wrapper.vm.$nextTick();
+    await wrapper.vm.$nextTick();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(alertSpy).toHaveBeenCalledWith('There was an error submitting your feedback. Please try again.');
+    expect(wrapper.emitted().close).toBeUndefined(); // Should not emit close on failure
+
+    alertSpy.mockRestore();
+  });
+});

--- a/app/components/common/tests/FeedbackModal.spec.ts
+++ b/app/components/common/tests/FeedbackModal.spec.ts
@@ -1,0 +1,87 @@
+// app/components/common/tests/FeedbackModal.spec.ts
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, vi } from 'vitest';
+import FeedbackModal from '../FeedbackModal.vue'; // Adjust path as needed
+
+// Mock child components
+const MockModal = {
+  template: '<div v-if="show" class="mock-modal"><slot /><slot name="footer" /></div>',
+  props: ['show'],
+  emits: ['close'], // Important: ensure mock emits events the parent listens to
+};
+
+const MockFeedbackForm = {
+  template: '<form class="mock-feedback-form"></form>',
+  emits: ['close'], // Important: ensure mock emits events the parent listens to
+};
+
+describe('FeedbackModal.vue', () => {
+  it('renders Modal and FeedbackForm when show is true', () => {
+    const wrapper = mount(FeedbackModal, {
+      props: { show: true },
+      global: {
+        stubs: {
+          Modal: MockModal,
+          FeedbackForm: MockFeedbackForm,
+        },
+      },
+    });
+
+    expect(wrapper.findComponent(MockModal).exists()).toBe(true);
+    expect(wrapper.findComponent(MockFeedbackForm).exists()).toBe(true);
+    expect(wrapper.find('.mock-modal').isVisible()).toBe(true); // Check based on MockModal's structure
+  });
+
+  it('does not render Modal content when show is false', () => {
+    const wrapper = mount(FeedbackModal, {
+      props: { show: false },
+      global: {
+        stubs: {
+          Modal: MockModal,
+          FeedbackForm: MockFeedbackForm,
+        },
+      },
+    });
+    // Depending on Modal.vue's actual behavior, it might still render the root element of Modal
+    // but hide it. We check if the *content* we expect is not there or not visible.
+    // If MockModal itself conditionally renders its slot based on `show`, this is simpler.
+    // Our MockModal uses v-if, so the .mock-modal div itself won't be in the DOM if show is false.
+    expect(wrapper.find('.mock-modal').exists()).toBe(false);
+  });
+
+  it('emits "close" when Modal emits "close"', async () => {
+    const wrapper = mount(FeedbackModal, {
+      props: { show: true },
+      global: {
+        stubs: {
+          Modal: MockModal,
+          FeedbackForm: MockFeedbackForm,
+        },
+      },
+    });
+
+    const modalComponent = wrapper.findComponent(MockModal);
+    await modalComponent.vm.$emit('close'); // Simulate Modal emitting close
+
+    expect(wrapper.emitted()).toHaveProperty('close');
+    expect(wrapper.emitted().close).toHaveLength(1);
+  });
+
+  it('emits "close" when FeedbackForm emits "close"', async () => {
+    const wrapper = mount(FeedbackModal, {
+      props: { show: true },
+      global: {
+        stubs: {
+          Modal: MockModal,
+          FeedbackForm: MockFeedbackForm,
+        },
+      },
+    });
+
+    const formComponent = wrapper.findComponent(MockFeedbackForm);
+    await formComponent.vm.$emit('close'); // Simulate FeedbackForm emitting close
+
+    expect(wrapper.emitted()).toHaveProperty('close');
+    expect(wrapper.emitted().close).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
I've implemented a chat feedback system that allows you to submit feedback through a popup form.

Key changes include:

-   Created `FeedbackButton.vue`: A floating button fixed to the bottom-right of the screen that triggers the feedback modal.
-   Created `FeedbackForm.vue`: A form component with fields for name, email, and message. It uses Formspree for submission.
-   Created `Modal.vue` enhancement: Added `max-h-[80vh] overflow-y-auto` for better handling of long content.
-   Created `FeedbackModal.vue`: Integrates `FeedbackForm` within the `Modal` component, managing its visibility.
-   Integrated the `FeedbackButton` and `FeedbackModal` into `app/app.vue` to make them globally available.
-   Added unit tests for `FeedbackButton.vue`, `FeedbackForm.vue`, and `FeedbackModal.vue` using Vitest and Vue Test Utils to ensure component reliability.
-   Styled components using Tailwind CSS, ensuring responsiveness and dark mode compatibility.